### PR TITLE
Fixed store initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@
 
 Basic code to use it with the last ember-data revision:
 
-      App.store = DS.Store.extend({
+      App.Store = DS.Store.extend({
         revision: 11,
         adapter: DS.DjangoRESTAdapter.create()
       });
 
-Creating with a namespace that will be used as the root url:
+Creating with a namespace (not to be confused with Django namespace urls) that will be used as the root url:
 
-      App.store = DS.Store.extend({
+      App.Store = DS.Store.extend({
         revision: 11,
         adapter: DS.DjangoRESTAdapter.create({
           namespace: "codecamp"
@@ -36,7 +36,7 @@ Creating with a namespace that will be used as the root url:
 Creating with a custom plural dictionary that will be used when a custom plural is needed:
 
       DS.DjangoRESTAdapter.configure("plurals", {"person" : "people"});
-      App.store = DS.Store.extend({
+      App.Store = DS.Store.extend({
         revision: 11,
         adapter: DS.DjangoRESTAdapter.create()
       });


### PR DESCRIPTION
`App.store` should be an instance (lowercase `s`), while `App.Store`
should be a class. It was mixed up, resulting in a non-functioning
store.

Also I found the namespace somewhat confusing at first, but it seems
it is named like that in the super `RESTAdapter`. So I added a note
about it.
