### PR TITLE
This one goes beyond 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@
 Basic code to use it with the last ember-data revision:
 
       App.Store = DS.Store.extend({
-        revision: 11,
+        revision: 12,
         adapter: DS.DjangoRESTAdapter.create()
       });
 
 Creating with a namespace (not to be confused with Django namespace urls) that will be used as the root url:
 
       App.Store = DS.Store.extend({
-        revision: 11,
+        revision: 12,
         adapter: DS.DjangoRESTAdapter.create({
           namespace: "codecamp"
         })
@@ -37,7 +37,7 @@ Creating with a custom plural dictionary that will be used when a custom plural 
 
       DS.DjangoRESTAdapter.configure("plurals", {"person" : "people"});
       App.Store = DS.Store.extend({
-        revision: 11,
+        revision: 12,
         adapter: DS.DjangoRESTAdapter.create()
       });
 


### PR DESCRIPTION
I've been using the adapter with success using Revision 12 of the protocol. However, server-side I'm adding `X_id` and `X_ids` to cover relationship fields. Should this be the case, or is there something missing in the serializer?
