### PR TITLE
nested url resolutions now use rootForType to get the correct root url

### DIFF
--- a/packages/ember-data-django-rest-adapter/lib/adapter.js
+++ b/packages/ember-data-django-rest-adapter/lib/adapter.js
@@ -137,15 +137,19 @@
             var root = this.rootForType(type);
             var url = this.buildURL(root);
             var parentType = store.typeForClientId(parent.get('clientId'));
-            var parentRoot = this.rootForType(parentType);
-            var record = {'parent_key': parentRoot, 'parent_value': parent.get('id')};
+            var record = Ember.Object.create({'parent_type': parentType, 'parent_value': parent.get('id')});
 
             return this.buildUrlWithParentWhenAvailable(record, url);
         },
 
         buildUrlWithParentWhenAvailable: function(record, url) {
+            var parent_type = record['parent_type'] || record.get('parent_type');
             var parent_key = record['parent_key'] || record.get('parent_key');
             var parent_value = record['parent_value'] || record.get('parent_value');
+
+            if (parent_type && parent_value) {
+                parent_key = this.rootForType(parent_type);
+            }
             if (parent_key && parent_value) {
                 var endpoint = url.split('/').reverse()[1];
                 var parent_plural = this.pluralize(parent_key);

--- a/packages/ember-data-django-rest-adapter/lib/serializer.js
+++ b/packages/ember-data-django-rest-adapter/lib/serializer.js
@@ -17,7 +17,7 @@
             if (!Ember.isNone(id)) {
                 hash[key] = id;
                 //provide the adapter with parent information for the create
-                record['parent_key'] = relationship.key;
+                record['parent_type'] = relationship.type;
                 record['parent_value'] = id;
             }
         }

--- a/tests/adapter_test.js
+++ b/tests/adapter_test.js
@@ -216,7 +216,7 @@ test("creating a task with associated person should invoke http post using the c
 
   store.commit();
 
-  expectUrlTypeData('/owners/2/tasks/', 'create URL', 'POST', { name: "Todo", is_finished: false, owner: "2" });
+  expectUrlTypeData('/people/2/tasks/', 'create URL', 'POST', { name: "Todo", is_finished: false, owner: "2" });
 
   ajaxHash.success({ id: 1, name: "Todo", owner: 2 }, Task);
   expectLoaded(task);
@@ -407,10 +407,11 @@ test('serializer adds parent_key and parent_value during addBelongsTo method', f
   var serializer = DS.DjangoRESTSerializer.create();
   var hash = {};
   var key = 'owner';
-  var relationship = {key:key};
+  var type = Person;
+  var relationship = {key:key, type:type};
   var record = store.find(Task, 1);
   serializer.addBelongsTo(hash, record, key, relationship);
-  equal(record.parent_key, 'owner');
+  equal(record.parent_type, type);
   equal(record.parent_value, 9);
   equal(hash.owner, 9);
 });


### PR DESCRIPTION
as per #9

this pr doesn't fix the other issue (with multiple belongsTo) but does fix the issue with differently named fields than models
