### PR TITLE
Upgrade to ember-data 13 and ember.js RC4/5

### DIFF
--- a/tests/adapter_test.js
+++ b/tests/adapter_test.js
@@ -13,8 +13,9 @@ DS.DjangoRESTAdapter.configure("plurals", {"person" : "people"});
 
 var TestAdapter = DS.DjangoRESTAdapter.extend({
   ajax: function(url, type, hash) {
-    var success = hash.success, error = hash.error, adapter = this;
-
+    var adapter = this;
+    hash = hash || {};
+    
     ajaxUrl = url;
     ajaxType = type;
     ajaxHash = hash;


### PR DESCRIPTION
emberjs/data@204fd3046e9c19b2e7f48f8a929e98df4a00e5b5

has changed some semantics of the ajax call, breaking some methods

trying to delete a record will cause an error in .ajax about hash being undefined.

the ajax call in their rest adapter has changed to return a promise and accept an undefined hash.

the changes need to be made here as well I suppose.

Although, looking at the override here, I don't see why an override is needed at all.  The default in DS.RESTAdapter seems like it would work fine.

Testing it with the function removed I see no issues, so I propose the ajax override be removed from here.
