### PR TITLE
add 2 tests to check correct de-camelizing of model names/attribute name...

### DIFF
--- a/packages/ember-data-django-rest-adapter/lib/adapter.js
+++ b/packages/ember-data-django-rest-adapter/lib/adapter.js
@@ -86,7 +86,8 @@ DS.DjangoRESTAdapter = DS.RESTAdapter.extend({
         });
         
         Ember.assert("could not find a relationship for the specified child type", typeof endpoint !== "undefined");
-        
+
+        endpoint = this.serializer.keyForAttributeName(parentType, endpoint);
         parentValue = parent.get('id');
         root = this.rootForType(parentType);
         url = this.buildURL(root, parentValue);


### PR DESCRIPTION
...s, fix issue with child endpoint not being properly de-camelized

Nested attributes that were camelCased on the Ember side were not properly being de-camelized:

`/camel_cases/:id/camelPeople/` was requested instead of `/camel_cases/:id/camel_people/`
