### PR TITLE
add failing test: when saved, a model with a hasmay relationship does no...

### DIFF
--- a/packages/ember-data-django-rest-adapter/lib/serializer.js
+++ b/packages/ember-data-django-rest-adapter/lib/serializer.js
@@ -30,5 +30,39 @@ DS.DjangoRESTSerializer = DS.RESTSerializer.extend({
     extractMany: function(loader, json, type, records) {
         json = this.patchInJSONRoot(json, type, true);
         this._super(loader, json, type, records);
+    },
+
+    // modified version of https://github.com/emberjs/data/blob/master/packages/ember-data/lib/serializers/json_serializer.js#L169
+    // Django Rest Framework expects a non-embedded has-many to serialize to an
+    // array of ids, but the JSONSeriarlizer assumed non-embedded relationship 
+    // updates would happen in the related model. 
+    addHasMany: function(hash, record, key, relationship) {
+      var type = record.constructor,
+        name = relationship.key,
+        serializedHasMany = [],
+        includeType = (relationship.options && relationship.options.polymorphic),
+        manyArray, embeddedType;
+
+      // Get the DS.ManyArray for the relationship off the record
+      // manyArray = get(record, name);
+      manyArray = record.get(name);
+
+      // If the has-many is not embedded, send just the array of ids.
+      embeddedType = this.embeddedType(type, name);
+      if (embeddedType !== 'always') {
+        // Build up the array of ids
+        manyArray.forEach(function (record) {
+          serializedHasMany.push(this.serializeId(record.id));
+        }, this);
+      } else {
+        // Build up the array of serialized records
+        manyArray.forEach(function (record) {
+          serializedHasMany.push(this.serialize(record, { includeId: true, includeType: includeType }));
+        }, this);
+      }
+
+      // Set the appropriate property of the serialized JSON to the
+      // array of serialized embedded records or array of ids
+      hash[key] = serializedHasMany;
     }
 });

--- a/packages/ember-data-django-rest-adapter/tests/unit/django_rest_adapter_test.js
+++ b/packages/ember-data-django-rest-adapter/tests/unit/django_rest_adapter_test.js
@@ -245,6 +245,43 @@ test("updating a person makes a PUT to /people/:id/ with the data hash", functio
     equal(get(person, 'name'), "Jane Doe", "the hash should be updated");
 });
 
+test("updating a group makes a PUT to /groups/:id/ with the data hash", function() {
+    // setup
+    var group, people;
+    store.load(Group, { id: 1, name: "Doe Family", zpeople: [ 1, 2 ] });
+    group = store.find(Group, 1);
+
+    // test
+    stateEquals(group, 'loaded.saved');
+    enabledFlags(group, ['isLoaded', 'isValid']);
+
+    // setup
+    set(group, 'name', 'New Doe Family Name');
+
+    // test
+    stateEquals(group, 'loaded.updated.uncommitted');
+    enabledFlags(group, ['isLoaded', 'isDirty', 'isValid']);
+
+    // setup
+    store.commit();
+
+    // test
+    stateEquals(group, 'loaded.updated.inFlight');
+    enabledFlags(group, ['isLoaded', 'isDirty', 'isSaving', 'isValid']);
+    expectUrl("/groups/1/", "the plural of the model name with its ID, and trailing slash");
+    expectType("PUT");
+    expectData({ name: "New Doe Family Name", zpeople: [1,2] });
+
+    // setup
+    ajaxHash.success({ id: 1, name: "New Doe Family Name" });
+
+    // test
+    stateEquals(group, 'loaded.saved');
+    enabledFlags(group, ['isLoaded', 'isValid']);
+    equal(group, store.find(Group, 1), "the same group is retrieved by the same ID");
+    equal(get(group, 'name'), "New Doe Family Name", "the hash should be updated");
+});
+
 test("deleting a person makes a DELETE to /people/:id/", function() {
     // setup
     var person;


### PR DESCRIPTION
...t send the array of ids to the server.

I noticed an issue where the `hasMany` relationship array of ids is not sent to the server during a `commit()` or `save()`. I added a test showing the same behavior.

In the test the `Group` model is defined as:

```
Group = DS.Model.extend({
    name: DS.attr('string'),
    zpeople: DS.hasMany(Person)
});
```

When we load a model it contains the array of `People` object ids in the `zpeople` array:

```
store.load(Group, { id: 1, name: "Doe Family", zpeople: [ 1, 2 ] });
group = store.find(Group, 1);
set(group, 'name', 'New Doe Family Name');
```

However, when we modify the loaded model and then call `store.commit()`, the data has sent to the server only contains the `name` attribute. 

![djangorestadaptererror](https://f.cloud.github.com/assets/1930208/873030/61a2a398-f86f-11e2-972f-83a0e8c10ce2.png)

In my real application I am seeing this same behavior.  When loading the JSON data from the server the array of ids is present, but when saving it the key is completely missing.  This causes the equivalent relationship on the server to be removed.

Am I missing how the hasMany relationship works?
