### PR TITLE
Ember1.0 add push payload capabilities

### DIFF
--- a/packages/ember-data-django-rest-adapter/lib/serializer.js
+++ b/packages/ember-data-django-rest-adapter/lib/serializer.js
@@ -44,6 +44,40 @@ DS.DjangoRESTSerializer = DS.RESTSerializer.extend({
     },
 
     /**
+      This method allows you to push a single object payload.
+
+      It will first normalize the payload, so you can use this to push
+      in data streaming in from your server structured the same way
+      that fetches and saves are structured.
+
+      @param {DS.Store} store
+      @param {String} type
+      @param {Object} payload
+    */
+    pushSinglePayload: function(store, type, payload) {
+        type = store.modelFor(type);
+        payload = this.extract(store, type, payload, null, "find");
+        store.push(type, payload);
+    },
+
+    /**
+      This method allows you to push an array of object payloads.
+
+      It will first normalize the payload, so you can use this to push
+      in data streaming in from your server structured the same way
+      that fetches and saves are structured.
+
+      @param {DS.Store} store
+      @param {String} type
+      @param {Object} payload
+    */
+    pushArrayPayload: function(store, type, payload) {
+        type = store.modelFor(type);
+        payload = this.extract(store, type, payload, null, "findAll");
+        store.pushMany(type, payload);
+    },
+
+    /**
       Converts camelcased attributes to underscored when serializing.
 
       Stolen from DS.ActiveModelSerializer.

--- a/tests/adapter_tests.js
+++ b/tests/adapter_tests.js
@@ -142,3 +142,37 @@ test('ajax response for single session will render correctly', function() {
         equal(ratings, 1, "table had " + ratings + " ratings");
     });
 });
+
+test('test pushSinglePayload', function() {
+    var json = {"id": 10, "description": "django"};
+    stubEndpointForHttpRequest('/api/sessions/', []);
+    Ember.run(App, function(){
+        // load the object into the Ember data store
+        var store = App.__container__.lookup("store:main");  // pretty sure this is not the right way to do this...
+        store.serializerFor('tag').pushSinglePayload(store, 'tag', json);
+    });
+    Ember.run(App, 'advanceReadiness');
+    visit("/tag/10").then(function() {
+        var content = $("span").text().trim();
+        equal(content, "django", "name was instead: " + content);
+    });
+});
+
+test('test pushArrayPayload', function() {
+    var json = [{"id": 11, "description": "ember"}, {"id": 12, "description": "tomster"}];
+    stubEndpointForHttpRequest('/api/sessions/', []);
+    Ember.run(App, function(){
+        // load the objects into the Ember data store
+        var store = App.__container__.lookup("store:main");  // pretty sure this is not the right way to do this...
+        store.serializerFor('tag').pushArrayPayload(store, 'tag', json);
+    });
+    Ember.run(App, 'advanceReadiness');
+    visit("/tag/12").then(function() {
+        var content = $("span").text().trim();
+        equal(content, "tomster", "name was instead: " + content);
+        return visit("/tag/11");
+    }).then(function(){
+        var content = $("span").text().trim();
+        equal(content, "ember", "name was instead: " + content);
+    });
+});

--- a/tests/app.js
+++ b/tests/app.js
@@ -211,6 +211,7 @@ App.Router.map(function() {
   this.resource("camels", { path : "/camels" });
   this.resource("camelUrls", { path : "/camelUrls" });
   this.resource("transformers", { path : "/transformers" });
+  this.resource("tag", { path : "/tag/:tag_id" });
 });
 
 App.ApplicationAdapter = DS.DjangoRESTAdapter.extend({

--- a/tests/templates/tag.handlebars
+++ b/tests/templates/tag.handlebars
@@ -1,0 +1,1 @@
+<span>{{content.description}}</span>


### PR DESCRIPTION
Provide the same functionality as the [`RESTSerializer`'s `pushPayload`](https://github.com/emberjs/data/blob/master/packages/ember-data/lib/serializers/rest_serializer.js#L508) but specific to our serializer/adapter.

This allows a single record or an array of records to be manually pushed into the store, such as when pre-loading records from the server.

```
var json = {"id": 10, "description": "django"};
// load the object into the Ember data store
var store = App.__container__.lookup("store:main");
store.serializerFor('tag').pushSinglePayload(store, 'tag', json);
```
