### PR TITLE
Ember1.0 use attribute name in url for hasmany

### DIFF
--- a/tests/adapter_tests.js
+++ b/tests/adapter_tests.js
@@ -43,7 +43,7 @@ test('models with camelCase converted to underscore urls', function() {
 
 test('keys with underscores converted to camelCase', function() {
     stubEndpointForHttpRequest('/api/sessions/', []);
-    stubEndpointForHttpRequest('/api/camels/1/tags/', tags_json);
+    stubEndpointForHttpRequest('/api/camels/1/camel_case_relationship/', tags_json);
     var json = [{"id": 1, "camel_case_attribute": "foo", "camel_case_relationship": [7]}];
     stubEndpointForHttpRequest('/api/camels/', json);
     Ember.run(App, 'advanceReadiness');
@@ -182,8 +182,7 @@ test('finding nested attributes makes GET request to the correct attribute-based
     var aliases = [{"id": 8, "name": "ember"}, {"id": 9, "name": "tomster"}];
     stubEndpointForHttpRequest('/api/sessions/', []);
     stubEndpointForHttpRequest('/api/users/1/', user);
-    stubEndpointForHttpRequest('/api/users/1/speakers/', aliases); //TODO remove this
-    //stubEndpointForHttpRequest('/api/users/1/aliases/', aliases); //TODO add this instead
+    stubEndpointForHttpRequest('/api/users/1/aliases/', aliases);
     Ember.run(App, 'advanceReadiness');
     visit("/user/1").then(function() {
         var name = $(".username").text().trim();


### PR DESCRIPTION
Fixes #40.
This uses the attribute name for hasMany relationships instead of the model type.

For a model like this

```
App.User = DS.Model.extend({
    username: DS.attr('string'),
    aliases: DS.hasMany('speaker', { async: true})
    favorites: DS.hasMany('speaker', { async: true})
});
```

requesting `user1.get('aliases')` would have caused the URL `/users/1/speaker` to be requested. This PR changes the behavior to use the name of the attribute instead, resulting in a request to `/users/1/aliases`. This also allows for multiple hasMany relationships to exist in a single model and be correctly requested.
