### PR TITLE
Ember1.0 robustify extractDjangoRelationship

### DIFF
--- a/packages/ember-data-django-rest-adapter/lib/serializer.js
+++ b/packages/ember-data-django-rest-adapter/lib/serializer.js
@@ -5,19 +5,16 @@ DS.DjangoRESTSerializer = DS.RESTSerializer.extend({
     },
 
     extractDjangoPayload: function(store, type, payload) {
-        for (var item in payload) {
-            if (!Ember.isNone(payload[item]) && typeof(payload[item][0]) !== 'number') {
-                if (payload[item].constructor.name === 'Array') {
-                    var singular_type = Ember.String.singularize(item);
-                    /*jshint loopfunc:true*/
-                    var ids = payload[item].map(function(related) {
-                        store.push(singular_type, related);
-                        return related.id; //todo find pk (not always id)
-                    });
-                    payload[item] = ids;
+        type.eachRelationship(function(key, relationship){
+            // TODO should we check if relationship is marked as embedded?
+            if (!Ember.isNone(payload[key]) && typeof(payload[key][0]) !== 'number') {
+                if (payload[key].constructor.name === 'Array' && payload[key].length > 0) {
+                    var ids = payload[key].mapBy('id'); //todo find pk (not always id)
+                    this.pushArrayPayload(store, relationship.type, payload[key]);
+                    payload[key] = ids;
                 }
             }
-        }
+        }, this);
     },
 
     extractSingle: function(store, type, payload) {

--- a/tests/adapter_tests.js
+++ b/tests/adapter_tests.js
@@ -15,6 +15,19 @@ module('integration tests', {
     }
 });
 
+test('arrays as result of transform should not be interpreted as embedded records', function() {
+    stubEndpointForHttpRequest('/api/sessions/', []);
+    var json = [{"id": 1, "config": "[\"ember\",\"is\",\"neato\"]"}];
+    stubEndpointForHttpRequest('/api/preserializeds/', json);
+    Ember.run(App, 'advanceReadiness');
+    visit("/preserialized").then(function() {
+        var divs = find("div.item").length;
+        equal(divs, 3, "found " + divs + " divs");
+        var items = $("div.item").text().trim();
+        equal(items, "emberisneato", "attribute was instead: " + items);
+    });
+});
+
 test('attribute transforms are applied', function() {
     stubEndpointForHttpRequest('/api/sessions/', []);
     var json = [{"id": 1, "transformed": "blah blah"}];

--- a/tests/app.js
+++ b/tests/app.js
@@ -12,6 +12,22 @@ App.SillyTransform = DS.Transform.extend({
   }
 });
 
+App.ObjectTransform = DS.Transform.extend({
+  deserialize: function(serialized) {
+    return Ember.isEmpty(serialized) ? {} : JSON.parse(serialized);
+  },
+  serialize: function(deserialized) {
+    return Ember.isNone(deserialized) ? '' : JSON.stringify(deserialized);
+  }
+});
+
+App.Preserialized = DS.Model.extend({
+  // This will contain JSON that will be deserialized by the App.ObjectTransform.
+  // If it deserializes to an array with anything other than numbers it will be 
+  // incorrectly interpreted by extractDjangoPayload as an embedded record.
+  config: DS.attr('object')
+});
+
 App.Transformer = DS.Model.extend({
   transformed: DS.attr('silly')
 });
@@ -104,6 +120,12 @@ App.OthersRoute = Ember.Route.extend({
 App.RatingsRoute = Ember.Route.extend({
   model: function() {
     return this.store.find('rating');
+  }
+});
+
+App.PreserializedRoute = Ember.Route.extend({
+  model: function() {
+    return this.store.find('preserialized');
   }
 });
 
@@ -213,6 +235,7 @@ App.Router.map(function() {
   this.resource("transformers", { path : "/transformers" });
   this.resource("tag", { path : "/tag/:tag_id" });
   this.resource("user", { path : "/user/:user_id" });
+  this.resource("preserialized", { path: "/preserialized" });
 });
 
 App.ApplicationAdapter = DS.DjangoRESTAdapter.extend({

--- a/tests/templates/preserialized.handlebars
+++ b/tests/templates/preserialized.handlebars
@@ -1,0 +1,5 @@
+{{#each record in controller}}
+  {{#each item in record.config}}
+    <div class="item">{{item}}</div>
+  {{/each}}
+{{/each}}


### PR DESCRIPTION
I store JSON objects in some models that deserialized to arrays which were being mistaken for embedded records by the old extractDjangoPayload method.

Changes to `extractDjangoPayload`:
- only check relationships for embedded records (can't have embedded records inside of normal attributes)
- use `DjangoRESTSerializer.pushArrayPayload` to make sure normalization is applied to embedded records.
