### PR TITLE
Tests showing creating and saving a model with async relationships does ...

### DIFF
--- a/tests/app.js
+++ b/tests/app.js
@@ -38,7 +38,8 @@ App.CamelUrl = DS.Model.extend({
 
 App.Camel = DS.Model.extend({
   camelCaseAttribute: DS.attr('string'),
-  camelCaseRelationship: DS.hasMany('tag', { async: true })
+  camelCaseRelationship: DS.hasMany('tag', { async: true }),
+  belongsToAsyncRelationship: DS.belongsTo('tag', { async: true })
 });
 
 App.Location = DS.Model.extend({


### PR DESCRIPTION
...not POST the relationship to the server.

The issue seems to be that a model with a relationship attribute that is marked
as `async: true` will return a promise when that attribute is accessed using
`get()`. This causes the `serializeBelongsTo()` or `serializeHasMany()` method in
the serializer to `get()` the relationship object and incorrectly assume it is
the actual model object, when a promise was instead retrieved.

For example, with an `async: true` relationship, this line is trying to get the
id of the related model object but it is instead accessing the id property of
a promise, which returns undefined:

https://github.com/toranb/ember-data-django-rest-adapter/blob/master/src/serializer.js#L123
