### PR TITLE
[BUGFIX] Use 'dasherize' instead of 'decamelize' when transforming model names

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -4,13 +4,11 @@ DS.DjangoRESTAdapter = DS.RESTAdapter.extend({
   defaultSerializer: "DS/djangoREST",
 
   /**
-   * Overrides the `pathForType` method to build underscored URLs.
-   *
-   * Stolen from ActiveModelAdapter
+   * Overrides the `pathForType` method to build dasherized URLs.
    *
    * ```js
    * this.pathForType("famousPerson");
-   * //=> "famous_people"
+   * //=> "famous-people"
    * ```
    *
    * @method pathForType
@@ -18,8 +16,8 @@ DS.DjangoRESTAdapter = DS.RESTAdapter.extend({
    * @returns String
    */
   pathForType: function(type) {
-    var decamelized = Ember.String.decamelize(type);
-    return Ember.String.pluralize(decamelized);
+    var dasherized = Ember.String.dasherize(type);
+    return Ember.String.pluralize(dasherized);
   },
 
   createRecord: function(store, type, record) {

--- a/tests/adapter_tests.js
+++ b/tests/adapter_tests.js
@@ -37,9 +37,9 @@ test('attribute transforms are applied', function() {
   });
 });
 
-test('models with camelCase converted to underscore urls', function() {
+test('models with camelCase converted to dasherized urls', function() {
   var json = [{"id": 1, "test": "foobar"}];
-  stubEndpointForHttpRequest('/api/camel_urls/', json);
+  stubEndpointForHttpRequest('/api/camel-urls/', json);
   visit("/camelUrls").then(function() {
     var spans = find("span").length;
     equal(spans, 1, "found " + spans + " spans");
@@ -395,9 +395,9 @@ test('multiword hasMany key is serialized correctly on save', function() {
     wait();
 });
 
-test('camelCase belongsTo key is serialized with underscores on save', function() {
+test('camelCase belongsTo key is serialized with dashes on save', function() {
   var store = App.__container__.lookup('store:main');
-  stubEndpointForHttpRequest('/api/camel_parents/1/', {'id': 1, 'name': 'parent'});
+  stubEndpointForHttpRequest('/api/camel-parents/1/', {'id': 1, 'name': 'parent'});
   visit("/camelParent").then(function() {
     stubEndpointForHttpRequest(
       '/api/camel_kids/', {"description":"firstkid","camel_parent":"1"}, 'POST', 201);


### PR DESCRIPTION
DRF uses dashes in root URLs, not underscores, e.g. `/api/school-teachers/`

This PR doesn't affect the rest of the URL in which DRF _does_ use underscores, e.g. `/api/children/4/school_teachers/`
