### PR TITLE
hasMany update for Ember Data 1.0.0-beta.9

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -199,7 +199,7 @@ DS.DjangoRESTSerializer = DS.RESTSerializer.extend({
 
     var key = relationship.key,
     json_key = this.keyForRelationship(key, "hasMany"),
-    relationshipType = record.constructor.determineRelationshipType(relationship);
+    relationshipType = DS.RelationshipChange ? DS.RelationshipChange.determineRelationshipType(record.constructor, relationship) : record.constructor.determineRelationshipType(relationship);
 
       if (relationshipType === 'manyToNone' || relationshipType === 'manyToMany') {
         json[json_key] = record.get(key).mapBy('id');


### PR DESCRIPTION
It seems `DS.RelationshipChange` is `undefined` in Ember Data 1.0.0-beta.9. As such `hasMany` relationships throws a `Cannot read property 'determineRelationshipType' of undefined`. Upon inspection of the source code of Ember Data 1.0.0-beta.9, the new code to be used is what has been added. I have confirmed this works.
