### PR TITLE
Avoid adjusting dates due to local timezone

### DIFF
--- a/src/transforms/date.js
+++ b/src/transforms/date.js
@@ -12,7 +12,11 @@ DS.DjangoDateTransform = DS.Transform.extend({
   },
   serialize: function(date) {
     if (date instanceof Date && date.toString() !== 'Invalid Date') {
-      return date.toISOString().slice(0, 10);
+      year = date.getFullYear();
+      month = date.getMonth() + 1;  // getMonth is 0-indexed
+      month = month < 10 ? '0' + month : month;
+      day = date.getDate();
+      return year + '-' + month + '-' + day;
     } else {
       return null;
     }


### PR DESCRIPTION
It seems that `Date.toISOString` applies a transformation to the Date object based on the user's local timezone.  This can often lead to unwanted data alterations when a date is serialized.  See #100.

/cc @benkonrath
